### PR TITLE
Fix edit itinerary date errors

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -166,19 +166,27 @@ public class EditCommandParser implements Parser<EditCommand> {
                     ParserUtil.parseDestination(argMultimap.getValue(PREFIX_ITINERARY_DESTINATION).get()));
         }
         if (argMultimap.getValue(PREFIX_ITINERARY_START).isPresent()) {
+            String startStr = argMultimap.getValue(PREFIX_ITINERARY_START).get();
+            if (!DateRange.isValidDateFormat(startStr)) {
+                throw new ParseException(DateRange.MESSAGE_INVALID_DATE_FORMAT);
+            }
             try {
                 editItineraryDescriptor.setStartDate(
-                        LocalDate.parse(argMultimap.getValue(PREFIX_ITINERARY_START).get(), DATE_FORMAT));
+                        LocalDate.parse(startStr, DATE_FORMAT));
             } catch (DateTimeParseException e) {
-                throw new ParseException(DateRange.MESSAGE_CONSTRAINTS);
+                throw new ParseException(DateRange.MESSAGE_INVALID_DATE);
             }
         }
         if (argMultimap.getValue(PREFIX_ITINERARY_END).isPresent()) {
+            String endStr = argMultimap.getValue(PREFIX_ITINERARY_END).get();
+            if (!DateRange.isValidDateFormat(endStr)) {
+                throw new ParseException(DateRange.MESSAGE_INVALID_DATE_FORMAT);
+            }
             try {
                 editItineraryDescriptor.setEndDate(
-                        LocalDate.parse(argMultimap.getValue(PREFIX_ITINERARY_END).get(), DATE_FORMAT));
+                        LocalDate.parse(endStr, DATE_FORMAT));
             } catch (DateTimeParseException e) {
-                throw new ParseException(DateRange.MESSAGE_CONSTRAINTS);
+                throw new ParseException(DateRange.MESSAGE_INVALID_DATE);
             }
         }
         if (!editItineraryDescriptor.isAnyFieldEdited()) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -104,8 +104,15 @@ public class CommandTestUtil {
 
     public static final String INVALID_ITINERARY_NAME_DESC = " " + PREFIX_ITINERARY_NAME + "_bali_";
     public static final String INVALID_ITINERARY_DEST_DESC = " " + PREFIX_ITINERARY_DESTINATION + " ";
-    public static final String INVALID_ITINERARY_START_DATE_DESC = " " + PREFIX_ITINERARY_START + "december 11 2026";
+
+    // invalid date format
+    public static final String INVALID_ITINERARY_START_DATE_FORMAT_DESC =
+            " " + PREFIX_ITINERARY_START + "december 11 2026";
+    public static final String INVALID_ITINERARY_END_DATE_FORMAT_DESC = " " + PREFIX_ITINERARY_END + "2026/01/01";
+    // invalid date
+    public static final String INVALID_ITINERARY_START_DATE_DESC = " " + PREFIX_ITINERARY_START + "2026-02-30";
     public static final String INVALID_ITINERARY_END_DATE_DESC = " " + PREFIX_ITINERARY_END + "2026-31-02";
+
     public static final String INVALID_INDEX_CLIENT_DESC = " " + PREFIX_ITINERARY_CLIENT + "abc";
     public static final String INVALID_INDEX_VENDOR_DESC = " " + PREFIX_ITINERARY_VENDOR + "___";
 

--- a/src/test/java/seedu/address/logic/parser/AddiCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddiCommandParserTest.java
@@ -5,8 +5,10 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_INDEX_CLIENT_
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_INDEX_VENDOR_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_DEST_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_END_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_END_DATE_FORMAT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_START_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_START_DATE_FORMAT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.ITINERARY_CLIENT_IDS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.ITINERARY_DEST_DESC_BALI;
 import static seedu.address.logic.commands.CommandTestUtil.ITINERARY_DEST_DESC_FRANCE;
@@ -146,12 +148,18 @@ public class AddiCommandParserTest {
                         + ITINERARY_START_DATE_DESC_BALI + ITINERARY_END_DATE_DESC_BALI,
                 Destination.MESSAGE_CONSTRAINTS);
 
-        // invalid start date
+        // invalid date format
+        assertParseFailure(parser, ITINERARY_NAME_DESC_BALI + ITINERARY_DEST_DESC_BALI
+                        + INVALID_ITINERARY_START_DATE_FORMAT_DESC + ITINERARY_END_DATE_DESC_BALI,
+                DateRange.MESSAGE_INVALID_DATE_FORMAT); // start date
+        assertParseFailure(parser, ITINERARY_NAME_DESC_BALI + ITINERARY_DEST_DESC_BALI
+                        + ITINERARY_START_DATE_DESC_BALI + INVALID_ITINERARY_END_DATE_FORMAT_DESC,
+                DateRange.MESSAGE_INVALID_DATE_FORMAT); // end date
+
+        // invalid date
         assertParseFailure(parser, ITINERARY_NAME_DESC_BALI + ITINERARY_DEST_DESC_BALI
                         + INVALID_ITINERARY_START_DATE_DESC + ITINERARY_END_DATE_DESC_BALI,
-                DateRange.MESSAGE_INVALID_DATE_FORMAT);
-
-        // invalid end date
+                DateRange.MESSAGE_INVALID_DATE);
         assertParseFailure(parser, ITINERARY_NAME_DESC_BALI + ITINERARY_DEST_DESC_BALI
                         + ITINERARY_START_DATE_DESC_BALI + INVALID_ITINERARY_END_DATE_DESC,
                 DateRange.MESSAGE_INVALID_DATE);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -295,11 +295,11 @@ public class EditCommandParserTest {
 
         // invalid start date
         assertParseFailure(parser, ITINERARY_FLAG + " 1"
-                + INVALID_ITINERARY_START_DATE_DESC, DateRange.MESSAGE_CONSTRAINTS);
+                + INVALID_ITINERARY_START_DATE_DESC, DateRange.MESSAGE_INVALID_DATE_FORMAT);
 
         // invalid end date
         assertParseFailure(parser, ITINERARY_FLAG + " 1"
-                + INVALID_ITINERARY_END_DATE_DESC, DateRange.MESSAGE_CONSTRAINTS);
+                + INVALID_ITINERARY_END_DATE_DESC, DateRange.MESSAGE_INVALID_DATE);
 
         // invalid destination followed by valid start date
         assertParseFailure(parser, ITINERARY_FLAG + " 1"

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -9,8 +9,10 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_DEST_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_END_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_END_DATE_FORMAT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_START_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ITINERARY_START_DATE_FORMAT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -293,11 +295,15 @@ public class EditCommandParserTest {
         assertParseFailure(parser, ITINERARY_FLAG + " 1"
                 + INVALID_ITINERARY_DEST_DESC, Destination.MESSAGE_CONSTRAINTS);
 
-        // invalid start date
+        // invalid date format
         assertParseFailure(parser, ITINERARY_FLAG + " 1"
-                + INVALID_ITINERARY_START_DATE_DESC, DateRange.MESSAGE_INVALID_DATE_FORMAT);
+                + INVALID_ITINERARY_START_DATE_FORMAT_DESC, DateRange.MESSAGE_INVALID_DATE_FORMAT);
+        assertParseFailure(parser, ITINERARY_FLAG + " 1"
+                + INVALID_ITINERARY_END_DATE_FORMAT_DESC, DateRange.MESSAGE_INVALID_DATE_FORMAT);
 
-        // invalid end date
+        // invalid date
+        assertParseFailure(parser, ITINERARY_FLAG + " 1"
+                + INVALID_ITINERARY_START_DATE_DESC, DateRange.MESSAGE_INVALID_DATE);
         assertParseFailure(parser, ITINERARY_FLAG + " 1"
                 + INVALID_ITINERARY_END_DATE_DESC, DateRange.MESSAGE_INVALID_DATE);
 


### PR DESCRIPTION
Fix #189 

16 LoC changed (EditCommandParser.java). Edit itinerary will now show all 3 errors for invalid dates:

<img width="506" height="170" alt="image" src="https://github.com/user-attachments/assets/e80f3f52-ef4b-4467-aace-ebda325b8525" />
<img width="568" height="183" alt="image" src="https://github.com/user-attachments/assets/a99f60e7-0610-491a-b16b-e6c82d1a8078" />
<img width="594" height="175" alt="image" src="https://github.com/user-attachments/assets/c7148b0a-96be-4482-bf2e-780e03b09be6" />

Tests also updated. 