### PR TITLE
Fix prefix case-sensitivity

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -70,7 +70,7 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        int prefixIndex = argsString.toLowerCase().indexOf((" " + prefix).toLowerCase(), fromIndex);
         return prefixIndex == -1 ? -1
                 : prefixIndex + 1; // +1 as offset for whitespace
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -100,6 +100,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @return True if the input does not contain any supported field-search prefixes, false otherwise.
      */
     public boolean isGlobalSearch(String trimmedArgs) {
+        trimmedArgs = trimmedArgs.toLowerCase();
         return !(trimmedArgs.contains(" n/") || trimmedArgs.startsWith("n/")
                 || trimmedArgs.contains(" p/") || trimmedArgs.startsWith("p/")
                 || trimmedArgs.contains(" e/") || trimmedArgs.startsWith("e/")

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -149,17 +149,13 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void equalsMethod() {
-        Prefix lowerCase = new Prefix("aaa");
-        Prefix mixedCase = new Prefix("aaa");
-        Prefix upperCase = new Prefix("aaa");
+        Prefix aaa = new Prefix("aaa");
 
-        assertEquals(lowerCase, lowerCase);
-        assertEquals(lowerCase, mixedCase);
-        assertEquals(lowerCase, upperCase);
-        assertEquals(lowerCase, new Prefix("aaa"));
+        assertEquals(aaa, aaa);
+        assertEquals(aaa, new Prefix("aaa"));
 
-        assertNotEquals(lowerCase, "aaa");
-        assertNotEquals(lowerCase, new Prefix("aab"));
+        assertNotEquals(aaa, "aaa");
+        assertNotEquals(aaa, new Prefix("aab"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -116,6 +116,17 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
+    public void tokenize_multipleArgumentsDifferentCase() {
+        String argsString = "Different Preamble String ^q111 -T dashT-Value P/pSlash value";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        assertPreamblePresent(argMultimap, "Different Preamble String");
+        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
+        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
+        assertArgumentPresent(argMultimap, hatQ, "111");
+    }
+
+
+    @Test
     public void tokenize_multipleArgumentsWithRepeats() {
         // Two arguments repeated, some have empty values
         String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
@@ -138,13 +149,17 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void equalsMethod() {
-        Prefix aaa = new Prefix("aaa");
+        Prefix lowerCase = new Prefix("aaa");
+        Prefix mixedCase = new Prefix("aaa");
+        Prefix upperCase = new Prefix("aaa");
 
-        assertEquals(aaa, aaa);
-        assertEquals(aaa, new Prefix("aaa"));
+        assertEquals(lowerCase, lowerCase);
+        assertEquals(lowerCase, mixedCase);
+        assertEquals(lowerCase, upperCase);
+        assertEquals(lowerCase, new Prefix("aaa"));
 
-        assertNotEquals(aaa, "aaa");
-        assertNotEquals(aaa, new Prefix("aab"));
+        assertNotEquals(lowerCase, "aaa");
+        assertNotEquals(lowerCase, new Prefix("aab"));
     }
 
 }


### PR DESCRIPTION
Fix #227 

Prefixes are case-insensitive now. Example (adding contact):
<img width="1251" height="59" alt="image" src="https://github.com/user-attachments/assets/aa83bda9-6158-4664-9d38-a6442a33a416" />
<img width="1526" height="100" alt="image" src="https://github.com/user-attachments/assets/0fad8d8b-f19c-46e8-82cb-eb500ff70276" />

3 LoC changed (ArgumentTokenizer.java, FindCommandParser.java)

Also added a test for this