### PR TITLE
Fix tag case-sensitivity

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -52,7 +52,7 @@ public class Tag {
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return tagName.toLowerCase().hashCode(); // Case-insensitive
     }
 
     /**


### PR DESCRIPTION
Related to #200 

When duplicate tags are added, the case of the first tag will be preserved, and the tag is only added once (e.g. The input `t/FRIENDS t/friends` is detected as duplicates, and only one tag `FRIENDS` is added to the contact).

<img width="570" height="74" alt="image" src="https://github.com/user-attachments/assets/23e920eb-2d4d-4608-a0f6-1022d583b87e" />
<img width="439" height="171" alt="image" src="https://github.com/user-attachments/assets/46237fc6-ebb9-42b0-8492-38a7d3cfb56e" />


Find will work as per normal (case-insenstive).